### PR TITLE
Fix: Add Bedrock InvokeModelWithResponseStream IAM permission

### DIFF
--- a/infrastructure/api.py
+++ b/infrastructure/api.py
@@ -158,8 +158,12 @@ def create_lambda_policy(
                             "Effect": "Allow",
                             "Action": [
                                 "bedrock:InvokeModel",
+                                "bedrock:InvokeModelWithResponseStream",
                             ],
-                            "Resource": "arn:aws:bedrock:*::foundation-model/us.amazon.nova-*",
+                            "Resource": [
+                                "arn:aws:bedrock:*::foundation-model/us.amazon.nova-*",
+                                "arn:aws:bedrock:*:*:inference-profile/*",
+                            ],
                         },
                     ]
                     if sessions_bucket


### PR DESCRIPTION
## Summary

Fixes #1 - Resolves the `AccessDeniedException` error when Lambda attempts to invoke Bedrock models with streaming.

## Problem

The Lambda IAM role `exec-assistant-lambda-role-dev` was missing the `bedrock:InvokeModelWithResponseStream` permission, causing the following error:

```
botocore.errorfactory.AccessDeniedException: An error occurred (AccessDeniedException) 
when calling the ConverseStream operation: User: arn:aws:sts::XXXX:assumed-role/exec-assistant-lambda-role-dev/exec-assistant-agent-dev 
is not authorized to perform: bedrock:InvokeModelWithResponseStream on resource: 
arn:aws:bedrock:us-east-1:xxxxxx:inference-profile/us.amazon.nova-lite-v1:0
```

## Changes Made

**File Modified:** `infrastructure/api.py` (lines 157-167)

### Before
```python
{
    "Effect": "Allow",
    "Action": [
        "bedrock:InvokeModel",
    ],
    "Resource": "arn:aws:bedrock:*::foundation-model/us.amazon.nova-*",
},
```

### After
```python
{
    "Effect": "Allow",
    "Action": [
        "bedrock:InvokeModel",
        "bedrock:InvokeModelWithResponseStream",
    ],
    "Resource": [
        "arn:aws:bedrock:*::foundation-model/us.amazon.nova-*",
        "arn:aws:bedrock:*:*:inference-profile/*",
    ],
},
```

## Key Fixes

1. **Added missing permission:** `bedrock:InvokeModelWithResponseStream` - Required for streaming Bedrock responses
2. **Updated Resource ARNs:** Expanded to support both:
   - Foundation models: `arn:aws:bedrock:*::foundation-model/us.amazon.nova-*`
   - Inference profiles: `arn:aws:bedrock:*:*:inference-profile/*`

## Testing

✅ **Deployment Successful:**
- Ran `pulumi preview` - No errors, validated changes
- Ran `pulumi up` - Successfully updated 35 resources in dev environment
- Lambda IAM role ARN: `arn:aws:iam::944945738659:role/exec-assistant-lambda-role-dev`
- Confirmed IAM policy includes both `bedrock:InvokeModel` and `bedrock:InvokeModelWithResponseStream`

## Impact

- **Scope:** IAM permissions only - no code changes
- **Risk:** Low - additive permissions, no removals
- **Environment:** Deployed to dev, ready for production

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>