### PR TITLE
Fix OAuth Redirect URI Configuration and Bedrock IAM Permissions

### DIFF
--- a/infrastructure/__main__.py
+++ b/infrastructure/__main__.py
@@ -14,8 +14,6 @@ from storage import create_dynamodb_tables, create_kms_key, create_s3_buckets
 try:
     from api import (
         create_agent_lambda,
-        create_api_gateway,
-        create_auth_lambda,
         create_lambda_policy,
         create_lambda_role,
         create_ui_bucket,

--- a/infrastructure/__main__.py
+++ b/infrastructure/__main__.py
@@ -85,11 +85,6 @@ if enable_phase_1_5 and PHASE_1_5_AVAILABLE:
         sessions_bucket=buckets["sessions"] if enable_phase_2 else None,
     )
 
-    # Create authentication Lambda function
-    auth_lambda = create_auth_lambda(environment, lambda_role, tables["users"], config)
-    pulumi.export("auth_lambda_arn", auth_lambda.arn)
-    pulumi.export("auth_lambda_name", auth_lambda.name)
-
     # Phase 2: Agent Lambda (optional)
     agent_lambda = None
     if enable_phase_2:
@@ -108,10 +103,22 @@ if enable_phase_1_5 and PHASE_1_5_AVAILABLE:
 
         pulumi.log.info("Phase 2: Agent Lambda created")
 
-    # Create API Gateway (with agent routes if Phase 2 enabled)
-    api, api_endpoint = create_api_gateway(environment, auth_lambda, agent_lambda)
+    # Create authentication Lambda and API Gateway together
+    # This ensures the auth Lambda gets the correct OAuth redirect URI
+    from api import create_auth_and_api_gateway
+
+    auth_lambda, api, api_endpoint = create_auth_and_api_gateway(
+        environment, lambda_role, tables["users"], config, agent_lambda
+    )
+
+    pulumi.export("auth_lambda_arn", auth_lambda.arn)
+    pulumi.export("auth_lambda_name", auth_lambda.name)
     pulumi.export("api_id", api.id)
     pulumi.export("api_endpoint", api_endpoint)
+
+    # Export the OAuth redirect URI for reference
+    oauth_redirect_uri = api_endpoint.apply(lambda endpoint: f"{endpoint}/auth/callback")
+    pulumi.export("oauth_redirect_uri", oauth_redirect_uri)
 
     # Create UI bucket for static website hosting
     ui_bucket, ui_website_url = create_ui_bucket(environment)

--- a/infrastructure/api.py
+++ b/infrastructure/api.py
@@ -161,6 +161,7 @@ def create_lambda_policy(
                                 "bedrock:InvokeModelWithResponseStream",
                             ],
                             "Resource": [
+                                "arn:aws:bedrock:*::foundation-model/amazon.nova-*",
                                 "arn:aws:bedrock:*::foundation-model/us.amazon.nova-*",
                                 "arn:aws:bedrock:*:*:inference-profile/*",
                             ],


### PR DESCRIPTION
## Summary

This PR fixes two critical infrastructure issues:
1. GOOGLE_OAUTH_REDIRECT_URI now uses the correct dynamic API Gateway endpoint
2. Bedrock IAM permissions now support all Nova model ARN patterns (fixes AccessDeniedException)

## Problem 1: OAuth Redirect URI

The auth Lambda was using a placeholder or incorrect value for `GOOGLE_OAUTH_REDIRECT_URI`, causing OAuth callback failures.

## Solution 1: Dynamic OAuth Configuration

Modified the infrastructure to dynamically construct the OAuth redirect URI from the actual API Gateway endpoint:

**Changes Made:**
- Modified `create_auth_lambda()` to accept optional `api_endpoint` parameter
- Created `create_auth_and_api_gateway()` wrapper function to solve circular dependency
- API Gateway is created first, then auth Lambda receives the correct redirect URI
- Added `oauth_redirect_uri` as a stack output for easy reference

**Result:**
```
GOOGLE_OAUTH_REDIRECT_URI=https://kcp7ctu6kg.execute-api.us-east-1.amazonaws.com/auth/callback
```

## Problem 2: Bedrock IAM AccessDeniedException

Lambda was receiving `AccessDeniedException` when invoking Bedrock models:
```
User: arn:aws:sts::944945738659:assumed-role/exec-assistant-lambda-role-dev/exec-assistant-agent-dev 
is not authorized to perform: bedrock:InvokeModelWithResponseStream on resource: 
arn:aws:bedrock:us-east-1::foundation-model/amazon.nova-lite-v1:0
```

The IAM policy only matched `us.amazon.nova-*` but the actual resource ARN was `amazon.nova-lite-v1:0` (without "us." prefix).

## Solution 2: Fixed IAM Policy ARN Patterns

Updated `infrastructure/api.py` to include all Nova model ARN patterns:

**Before:**
```python
"Resource": [
    "arn:aws:bedrock:*::foundation-model/us.amazon.nova-*",
    "arn:aws:bedrock:*:*:inference-profile/*",
]
```

**After:**
```python
"Resource": [
    "arn:aws:bedrock:*::foundation-model/amazon.nova-*",  # NEW - fixes the error
    "arn:aws:bedrock:*::foundation-model/us.amazon.nova-*",
    "arn:aws:bedrock:*:*:inference-profile/*",
]
```

## Additional Cleanup

- Removed unused imports from `__main__.py` (`create_api_gateway`, `create_auth_lambda`)

## Testing

✅ **Deployment Successful:**
- Ran `pulumi up --yes` in dev environment
- Updated 3 resources: IAM policy + 2 Lambda functions
- 32 resources unchanged
- Duration: 5m41s
- No errors reported

## Verification

**Lambda IAM Role:** `arn:aws:iam::944945738659:role/exec-assistant-lambda-role-dev`

**Environment Variables Set:**
- Auth Lambda: `GOOGLE_OAUTH_REDIRECT_URI=https://kcp7ctu6kg.execute-api.us-east-1.amazonaws.com/auth/callback`

**IAM Permissions:** Includes both `bedrock:InvokeModel` and `bedrock:InvokeModelWithResponseStream` for all Nova models

## Impact

- **Scope:** IAM permissions + environment variable configuration
- **Risk:** Low - additive changes only, no removals
- **Environment:** Deployed and tested in dev

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>